### PR TITLE
[ ci ] install chezscheme from hirsute

### DIFF
--- a/.github/workflows/ci-ubuntu-combined.yml
+++ b/.github/workflows/ci-ubuntu-combined.yml
@@ -32,13 +32,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Install build dependencies
         run: |
-          # sudo apt-get install -y chezscheme
-          # apt lags behind the version we need (9.5.1+)
-          git clone https://github.com/cisco/ChezScheme
-          cd ChezScheme
-          ./configure
-          sudo make install
-          echo "::add-path::$HOME/.idris2/bin"
+          echo "deb http://security.ubuntu.com/ubuntu hirsute universe" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
+          sudo apt-get install -y -t hirsute chezscheme
       - name: Build from bootstrap
         run: make bootstrap && make install
       - name: Artifact Bootstrapped Idris2
@@ -77,7 +73,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Install build dependencies
         run: |
-          sudo apt-get install -y chezscheme
+          echo "deb http://security.ubuntu.com/ubuntu hirsute universe" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
+          sudo apt-get install -y -t hirsute chezscheme
           echo "::add-path::$HOME/.idris2/bin"
       - name: Cache Chez Previous Version
         id: previous-version-cache
@@ -124,7 +122,9 @@ jobs:
           path: ~/.idris2/
       - name: Install build dependencies
         run: |
-          sudo apt-get install -y chezscheme
+          echo "deb http://security.ubuntu.com/ubuntu hirsute universe" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
+          sudo apt-get install -y -t hirsute chezscheme
           echo "::add-path::$HOME/.idris2/bin"
           chmod +x $HOME/.idris2/bin/idris2 $HOME/.idris2/bin/idris2_app/*
       - name: Build self-hosted
@@ -172,7 +172,9 @@ jobs:
           path: ~/.idris2/
       - name: Install build dependencies
         run: |
-          sudo apt-get install -y chezscheme
+          echo "deb http://security.ubuntu.com/ubuntu hirsute universe" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
+          sudo apt-get install -y -t hirsute chezscheme
           echo "::add-path::$HOME/.idris2/bin"
           chmod +x $HOME/.idris2/bin/idris2 $HOME/.idris2/bin/idris2_app/*
       - name: Build from previous version
@@ -203,7 +205,9 @@ jobs:
           path: ~/.idris2/
       - name: Install build dependencies
         run: |
-          sudo apt-get install -y chezscheme
+          echo "deb http://security.ubuntu.com/ubuntu hirsute universe" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
+          sudo apt-get install -y -t hirsute chezscheme
           echo "::add-path::$HOME/.idris2/bin"
           chmod +x $HOME/.idris2/bin/idris2 $HOME/.idris2/bin/idris2_app/*
       - name: Build API


### PR DESCRIPTION
This should fix the build.

Ubuntu users ought to be able to add the hirsute repo & set preferences
so that it's only used for `chezscheme` so this is actually a viable solution.

We should however consider adding a little bit of magic detecting the version
of the installed scheme and only produce this type of code if the compiler is
recent enough. This way people stuck with old versions of chez can still compile
and use Idris2 as long as they don't use the FFI in a multi-threaded setting.